### PR TITLE
Separate importer types

### DIFF
--- a/psamm_import/datasource/cobrajson.py
+++ b/psamm_import/datasource/cobrajson.py
@@ -35,6 +35,7 @@ class Importer(BaseImporter):
 
     name = 'cobra-json'
     title = 'COBRA JSON'
+    generic = True
 
     def help(self):
         print('Source must contain the model definition in COBRA JSON'

--- a/psamm_import/datasource/excel.py
+++ b/psamm_import/datasource/excel.py
@@ -1368,6 +1368,7 @@ class ImportModelSEED(Importer):
 
     name = 'ModelSEED'
     title = 'ModelSEED model (Excel format)'
+    generic = True
 
     def help(self):
         print('Source must contain the model definition in Excel format\n'

--- a/psamm_import/datasource/sbml.py
+++ b/psamm_import/datasource/sbml.py
@@ -75,6 +75,7 @@ class StrictImporter(BaseImporter):
 
     name = 'SBML-strict'
     title = 'SBML model (strict)'
+    generic = True
 
     def _open_reader(self, f):
         try:
@@ -88,6 +89,7 @@ class NonstrictImporter(BaseImporter):
 
     name = 'SBML'
     title = 'SBML model (non-strict)'
+    generic = True
 
     def _open_reader(self, f):
         try:

--- a/psamm_import/importer.py
+++ b/psamm_import/importer.py
@@ -17,6 +17,8 @@
 
 """Generic native model importer"""
 
+from __future__ import print_function
+
 import sys
 import os
 import argparse
@@ -367,7 +369,6 @@ def main():
 
     # Print list of importers
     if args.format in ('list', 'help'):
-        print('Available importers:')
         if len(importers) == 0:
             logger.error('No importers found!')
         else:
@@ -375,11 +376,21 @@ def main():
             for name, entry in iteritems(importers):
                 importer_class = entry.load()
                 title = getattr(importer_class, 'title', None)
+                generic = getattr(importer_class, 'generic', False)
                 if title is not None:
-                    importer_classes.append((title, name, importer_class))
+                    importer_classes.append(
+                        (title, generic, name, importer_class))
 
-            for title, name, importer_class in sorted(importer_classes):
-                print('{:<10}  {}'.format(name, title))
+            print('Generic importers:')
+            for title, _, name, importer_class in sorted(
+                    c for c in importer_classes if c[1]):
+                print('{:<12}  {}'.format(name, title))
+
+            print()
+            print('Model-specific importers:')
+            for title, _, name, importer_class in sorted(
+                    c for c in importer_classes if not c[1]):
+                print('{:<12}  {}'.format(name, title))
         sys.exit(0)
 
     importer_name = args.format.lower()


### PR DESCRIPTION
Instead of printing one list of all importers, the list of importers is now split into two lists, one for generic importers and one for model-specific importers. This makes it easier to locate the desired importer in the list. The importers for SBML, COBRA JSON and ModelSEED are currently marked as generic importers.
