### PR TITLE
Model refactor

### DIFF
--- a/psamm_import/datasource/cobrajson.py
+++ b/psamm_import/datasource/cobrajson.py
@@ -70,8 +70,8 @@ class Importer(BaseImporter):
     def _import(self, file):
         model_doc = json.load(file, parse_float=_float_parser)
         model = MetabolicModel(
-            model_doc.get('id', 'COBRA JSON model'),
             self._read_compounds(model_doc), self._read_reactions(model_doc))
+        model.name = model_doc.get('id', 'COBRA JSON model')
 
         biomass_reaction = None
         objective_reactions = set()

--- a/psamm_import/datasource/cobrajson.py
+++ b/psamm_import/datasource/cobrajson.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2015-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Importer for the COBRApy JSON format."""
 
@@ -26,9 +26,10 @@ import decimal
 from six import iteritems
 
 from psamm.reaction import Reaction, Compound, Direction
+from psamm.datasource.entry import (DictCompoundEntry as CompoundEntry,
+                                    DictReactionEntry as ReactionEntry)
 
-from ..model import (Importer as BaseImporter, ModelLoadError,
-                     CompoundEntry, ReactionEntry, MetabolicModel)
+from ..model import Importer as BaseImporter, ModelLoadError, MetabolicModel
 
 logger = logging.getLogger(__name__)
 
@@ -104,8 +105,8 @@ class Importer(BaseImporter):
             else:
                 formula = None
 
-            yield CompoundEntry(id=id, name=name, charge=charge,
-                                formula=formula)
+            yield CompoundEntry(dict(
+                id=id, name=name, charge=charge, formula=formula))
 
     def _parse_reaction_equation(self, r):
         compounds = ((Compound(metabolite), value)
@@ -133,9 +134,10 @@ class Importer(BaseImporter):
             if genes is not None:
                 genes = self._try_parse_gene_association(id, genes)
 
-            yield ReactionEntry(id=id, name=name, equation=equation,
-                                lower_flux=lower_flux, upper_flux=upper_flux,
-                                subsystem=subsystem, genes=genes)
+            yield ReactionEntry(dict(
+                id=id, name=name, equation=equation,
+                lower_flux=lower_flux, upper_flux=upper_flux,
+                subsystem=subsystem, genes=genes))
 
     def import_model(self, source):
         """Import and return model instance."""

--- a/psamm_import/datasource/excel.py
+++ b/psamm_import/datasource/excel.py
@@ -55,8 +55,8 @@ class ImportiMA945(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.biomass_reaction = 'ST_biomass_core'
         model.extracellular_compartment = 'e'
 
@@ -173,8 +173,8 @@ class ImportiRR1083(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.extracellular_compartment = 'e'
 
         return model
@@ -258,8 +258,8 @@ class ImportiJO1366(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.biomass_reaction = 'Ec_biomass_iJO1366_core_53p95M'
         model.extracellular_compartment = 'e'
 
@@ -348,8 +348,8 @@ class EColiTextbookImport(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.extracellular_compartment = 'e'
 
         return model
@@ -441,8 +441,8 @@ class ImportSTMv1_0(Importer):  # noqa
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.biomass_reaction = 'biomass_iRR1083_metals'
         model.extracellular_compartment = 'e'
 
@@ -529,8 +529,8 @@ class ImportiJN746(Importer):
         self._compound_book = xlrd.open_workbook(compound_source)
         self._reaction_book = xlrd.open_workbook(reaction_source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.extracellular_compartment = 'e'
 
         return model
@@ -620,8 +620,8 @@ class ImportiJP815(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
 
         return model
 
@@ -705,8 +705,8 @@ class ImportiSyn731(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.biomass_reaction = 'Biomass_Hetero'
         model.extracellular_compartment = 'e'
 
@@ -799,8 +799,8 @@ class ImportiCce806(Importer):
         self._compound_book = xlrd.open_workbook(compound_source)
         self._reaction_book = xlrd.open_workbook(reaction_source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.biomass_reaction = 'CyanoBM (average)'
         model.extracellular_compartment = 'e'
 
@@ -933,8 +933,8 @@ class ImportGSMN_TB(Importer):  # noqa
         self._compound_book = xlrd.open_workbook(compound_source)
         self._reaction_book = xlrd.open_workbook(reaction_source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
 
         return model
 
@@ -1041,8 +1041,8 @@ class ImportiNJ661(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            self.title, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = self.title
         model.extracellular_compartment = 'e'
 
         return model
@@ -1123,8 +1123,8 @@ class ImportGenericiNJ661mv(Importer):
 
         self._book = xlrd.open_workbook(source)
 
-        model = MetabolicModel(
-            name, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = name
         model.biomass_reaction = 'biomass_Mtb_9_60atp_test_NOF'
         model.extracellular_compartment = 'e'
 
@@ -1233,8 +1233,8 @@ class ImportShewanellaOng(Importer):
         self._book = xlrd.open_workbook(source)
         self._col_index = col_index
 
-        model = MetabolicModel(
-            name, self._read_compounds(), self._read_reactions())
+        model = MetabolicModel(self._read_compounds(), self._read_reactions())
+        model.name = name
         model.biomass_reaction = self.biomass_names[col_index]
         model.extracellular_compartment = 'e'
 
@@ -1450,8 +1450,8 @@ class ImportModelSEED(Importer):
             peg_mapping[peg_id] = location_mapping[start, stop, direction]
 
         model = MetabolicModel(
-            'ModelSEED model', self._read_compounds(),
-            self._read_reactions(peg_mapping))
+            self._read_compounds(), self._read_reactions(peg_mapping))
+        model.name = 'ModelSEED model'
 
         return model
 

--- a/psamm_import/datasource/excel.py
+++ b/psamm_import/datasource/excel.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2015-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2015-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 # Copyright 2015  Keith Dufault-Thompson <keitht547@my.uri.edu>
 
 """Importers for various Excel formats."""
@@ -27,11 +27,13 @@ import xlrd
 from six import string_types
 
 from psamm.datasource.reaction import ReactionParser
+from psamm.datasource.entry import (DictCompoundEntry as CompoundEntry,
+                                    DictReactionEntry as ReactionEntry)
+from psamm.datasource.context import FileMark, FilePathContext
 from psamm.reaction import Reaction, Compound, Direction
 from psamm.expression import boolean
 
-from ..model import (Importer, ModelLoadError, CompoundEntry, ReactionEntry,
-                     MetabolicModel)
+from ..model import Importer, ModelLoadError, MetabolicModel
 
 
 class ImportiMA945(Importer):
@@ -50,10 +52,12 @@ class ImportiMA945(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -100,10 +104,11 @@ class ImportiMA945(Importer):
 
             kegg = None if kegg == '' else kegg
 
-            yield CompoundEntry(id=compound_id, name=name,
-                                formula=formula,
-                                formula_neutral=formula_neutral,
-                                charge=charge, kegg=kegg)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula,
+                formula_neutral=formula_neutral,
+                charge=charge, kegg=kegg), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -147,8 +152,10 @@ class ImportiMA945(Importer):
 
             genes = self._try_parse_gene_association(reaction_id, genes)
 
-            yield ReactionEntry(id=reaction_id, name=name,
-                                genes=genes, equation=equation)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name,
+                genes=genes, equation=equation), filemark=filemark)
 
 
 class ImportiRR1083(Importer):
@@ -168,10 +175,12 @@ class ImportiRR1083(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -200,10 +209,12 @@ class ImportiRR1083(Importer):
 
             kegg = None if kegg == '' else kegg
 
-            yield CompoundEntry(id=compound_id, name=name,
-                                formula=formula_neutral,
-                                formula_neutral=formula_neutral,
-                                charge=charge, kegg=kegg)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name,
+                formula=formula_neutral,
+                formula_neutral=formula_neutral,
+                charge=charge, kegg=kegg), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -232,8 +243,10 @@ class ImportiRR1083(Importer):
 
             subsystem = None if subsystem == '' else subsystem
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation), filemark=filemark)
 
 
 class ImportiJO1366(Importer):
@@ -253,10 +266,12 @@ class ImportiJO1366(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -289,10 +304,12 @@ class ImportiJO1366(Importer):
             kegg = None if kegg.strip() == '' else kegg
             cas = None if cas.strip() == '' else cas
 
-            yield CompoundEntry(id=compound_id, name=name,
-                                formula=formula,
-                                formula_neutral=formula_neutral,
-                                charge=charge, kegg=kegg, cas=cas)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name,
+                formula=formula,
+                formula_neutral=formula_neutral,
+                charge=charge, kegg=kegg, cas=cas), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -321,9 +338,11 @@ class ImportiJO1366(Importer):
             subsystem = None if subsystem.strip() == '' else subsystem
             ec = None if ec.strip() == '' else ec
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem,
-                                ec=ec)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem,
+                ec=ec), filemark=filemark)
 
 
 class EColiTextbookImport(Importer):
@@ -343,10 +362,12 @@ class EColiTextbookImport(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -383,10 +404,12 @@ class EColiTextbookImport(Importer):
             cas = None if cas.strip() == '' or cas == 'None' else cas
             kegg = None if kegg.strip() == '' else kegg
 
-            yield CompoundEntry(id=compound_id, name=name,
-                                formula=formula,
-                                formula_neutral=formula_neutral,
-                                charge=charge, kegg=kegg, cas=cas)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name,
+                formula=formula,
+                formula_neutral=formula_neutral,
+                charge=charge, kegg=kegg, cas=cas), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -415,8 +438,10 @@ class EColiTextbookImport(Importer):
             subsystem = None if subsystem.strip() == '' else subsystem
             ec = None if ec.strip() == '' else ec
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem, ec=ec)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes, equation=equation,
+                subsystem=subsystem, ec=ec), filemark=filemark)
 
 
 class ImportSTMv1_0(Importer):  # noqa
@@ -436,10 +461,12 @@ class ImportSTMv1_0(Importer):  # noqa
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -467,8 +494,10 @@ class ImportSTMv1_0(Importer):  # noqa
 
             kegg = None if kegg.strip() == '' else kegg
 
-            yield CompoundEntry(id=compound_id, name=name,
-                                formula=formula, charge=charge, kegg=kegg)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name,
+                formula=formula, charge=charge, kegg=kegg), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -496,9 +525,11 @@ class ImportSTMv1_0(Importer):  # noqa
             subsystem = None if subsystem.strip() == '' else subsystem
             genes = self._try_parse_gene_association(reaction_id, genes)
 
-            yield ReactionEntry(id=reaction_id, name=name,
-                                genes=genes, equation=equation,
-                                subsystem=subsystem)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name,
+                genes=genes, equation=equation,
+                subsystem=subsystem), filemark=filemark)
 
 
 class ImportiJN746(Importer):
@@ -520,14 +551,18 @@ class ImportiJN746(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            compound_source = os.path.join(source, self.filenames[0])
-            reaction_source = os.path.join(source, self.filenames[1])
-        else:
+        if not os.path.isdir(source):
             raise ModelLoadError('Source must be a directory')
 
-        self._compound_book = xlrd.open_workbook(compound_source)
-        self._reaction_book = xlrd.open_workbook(reaction_source)
+        self._compound_context = FilePathContext(
+            os.path.join(source, self.filenames[0]))
+        self._reaction_context = FilePathContext(
+            os.path.join(source, self.filenames[1]))
+
+        self._compound_book = xlrd.open_workbook(
+            self._compound_context.filepath)
+        self._reaction_book = xlrd.open_workbook(
+            self._reaction_context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -562,9 +597,11 @@ class ImportiJN746(Importer):
             else:
                 cas = str(cas)
 
-            yield CompoundEntry(id=compound_id, name=name, formula=formula,
-                                formula_neutral=formula_neutral,
-                                charge=charge, kegg=kegg, cas=cas)
+            filemark = FileMark(self._compound_context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula,
+                formula_neutral=formula_neutral,
+                charge=charge, kegg=kegg, cas=cas), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -593,9 +630,11 @@ class ImportiJN746(Importer):
             ec = None if ec.strip() == '' else ec
             genes = self._try_parse_gene_association(reaction_id, genes)
 
-            yield ReactionEntry(id=reaction_id, name=name,
-                                genes=genes, equation=equation,
-                                subsystem=subsystem, ec=ec)
+            filemark = FileMark(self._reaction_context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name,
+                genes=genes, equation=equation,
+                subsystem=subsystem, ec=ec), filemark=filemark)
 
 
 class ImportiJP815(Importer):
@@ -615,10 +654,12 @@ class ImportiJP815(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -642,7 +683,9 @@ class ImportiJP815(Importer):
             if m:
                 name = m.group(1)
 
-            yield CompoundEntry(id=compound_id, name=name, kegg=kegg)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, kegg=kegg), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -679,8 +722,10 @@ class ImportiJP815(Importer):
             subsystem = None if subsystem.strip() == '' else subsystem
             genes = self._try_parse_gene_association(reaction_id, genes)
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem), filemark=filemark)
 
 
 class ImportiSyn731(Importer):
@@ -700,10 +745,12 @@ class ImportiSyn731(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -739,8 +786,10 @@ class ImportiSyn731(Importer):
             else:
                 kegg = None
 
-            yield CompoundEntry(id=compound_id, name=name, formula=formula,
-                                charge=charge, kegg=kegg)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula,
+                charge=charge, kegg=kegg), filemark=filemark)
 
     def _read_reactions(self):
         sheet = self._book.sheet_by_name('Model')
@@ -767,8 +816,11 @@ class ImportiSyn731(Importer):
             genes = self._try_parse_gene_association(reaction_id, genes)
             ec = ec if ec.strip() != '' and ec != 'Undetermined' else None
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem, ec=ec)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem,
+                ec=ec), filemark=filemark)
 
 
 class ImportiCce806(Importer):
@@ -790,14 +842,18 @@ class ImportiCce806(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            reaction_source = os.path.join(source, self.filenames[0])
-            compound_source = os.path.join(source, self.filenames[1])
-        else:
+        if not os.path.isdir(source):
             raise ModelLoadError('Source must be a directory')
 
-        self._compound_book = xlrd.open_workbook(compound_source)
-        self._reaction_book = xlrd.open_workbook(reaction_source)
+        self._compound_context = FilePathContext(
+            os.path.join(source, self.filenames[1]))
+        self._reaction_context = FilePathContext(
+            os.path.join(source, self.filenames[0]))
+
+        self._compound_book = xlrd.open_workbook(
+            self._compound_context.filepath)
+        self._reaction_book = xlrd.open_workbook(
+            self._reaction_context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -840,9 +896,11 @@ class ImportiCce806(Importer):
             else:
                 cas = None
 
-            yield CompoundEntry(id=compound_id, name=name, formula=formula,
-                                formula_neutral=formula, charge=charge,
-                                kegg=kegg, cas=cas)
+            filemark = FileMark(self._compound_context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula,
+                formula_neutral=formula, charge=charge,
+                kegg=kegg, cas=cas), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -901,8 +959,11 @@ class ImportiCce806(Importer):
             else:
                 ec = None
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem, ec=ec)
+            filemark = FileMark(self._reaction_context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem,
+                ec=ec), filemark=filemark)
 
 
 class ImportGSMN_TB(Importer):  # noqa
@@ -924,14 +985,18 @@ class ImportGSMN_TB(Importer):  # noqa
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            reaction_source = os.path.join(source, self.filenames[0])
-            compound_source = os.path.join(source, self.filenames[1])
-        else:
+        if not os.path.isdir(source):
             raise ModelLoadError('Source must be a directory')
 
-        self._compound_book = xlrd.open_workbook(compound_source)
-        self._reaction_book = xlrd.open_workbook(reaction_source)
+        self._compound_context = FilePathContext(
+            os.path.join(source, self.filenames[1]))
+        self._reaction_context = FilePathContext(
+            os.path.join(source, self.filenames[0]))
+
+        self._compound_book = xlrd.open_workbook(
+            self._compound_context.filepath)
+        self._reaction_book = xlrd.open_workbook(
+            self._reaction_context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -953,12 +1018,14 @@ class ImportGSMN_TB(Importer):  # noqa
 
             name = None if name.strip() == '' else name
 
-            yield CompoundEntry(id=compound_id, name=name)
+            filemark = FileMark(self._compound_context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name), filemark=filemark)
 
         def create_missing(compound_id, name=None):
             if name is None:
                 name = compound_id
-            return CompoundEntry(id=compound_id, name=name)
+            return CompoundEntry(dict(id=compound_id, name=name))
 
         # Generate missing compounds
         yield create_missing('MBT-HOLO', 'Mycobactin-Holo')
@@ -1015,8 +1082,11 @@ class ImportGSMN_TB(Importer):  # noqa
             subsystem = None if subsystem.strip() == '' else subsystem
             ec = None if ec.strip() == '' else ec
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem, ec=ec)
+            filemark = FileMark(self._reaction_context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem,
+                ec=ec), filemark=filemark)
 
 
 class ImportiNJ661(Importer):
@@ -1036,10 +1106,12 @@ class ImportiNJ661(Importer):
 
     def import_model(self, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = self.title
@@ -1064,8 +1136,10 @@ class ImportiNJ661(Importer):
             except ValueError:
                 charge = None
 
-            yield CompoundEntry(id=compound_id, name=name, formula=formula,
-                                charge=charge)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula,
+                charge=charge), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -1099,8 +1173,10 @@ class ImportiNJ661(Importer):
 
             subsystem = None if subsystem.strip() == '' else subsystem
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem), filemark=filemark)
 
 
 class ImportGenericiNJ661mv(Importer):
@@ -1118,10 +1194,12 @@ class ImportGenericiNJ661mv(Importer):
 
     def import_model_named(self, name, source):
         """Import and return model instance with the given name."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
         model.name = name
@@ -1141,7 +1219,9 @@ class ImportGenericiNJ661mv(Importer):
 
             formula = self._try_parse_formula(compound_id, formula)
 
-            yield CompoundEntry(id=compound_id, name=name, formula=formula)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -1171,8 +1251,10 @@ class ImportGenericiNJ661mv(Importer):
 
             subsystem = None if subsystem.strip() == '' else subsystem
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem), filemark=filemark)
 
 
 class ImportiNJ661m(ImportGenericiNJ661mv):
@@ -1227,10 +1309,12 @@ class ImportShewanellaOng(Importer):
 
     def import_model_named(self, name, col_index, source):
         """Import and return model instance."""
-        if os.path.isdir(source):
-            source = os.path.join(source, self.filename)
+        context = FilePathContext(source)
+        if os.path.isdir(context.filepath):
+            context = FilePathContext(os.path.join(source, self.filename))
 
-        self._book = xlrd.open_workbook(source)
+        self._context = context
+        self._book = xlrd.open_workbook(context.filepath)
         self._col_index = col_index
 
         model = MetabolicModel(self._read_compounds(), self._read_reactions())
@@ -1267,9 +1351,11 @@ class ImportShewanellaOng(Importer):
             else:
                 cas = str(cas)
 
-            yield CompoundEntry(id=compound_id, name=name, formula=formula,
-                                formula_neutral=formula_neutral, charge=charge,
-                                kegg=kegg, cas=cas)
+            filemark = FileMark(self._context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula,
+                formula_neutral=formula_neutral, charge=charge,
+                kegg=kegg, cas=cas), filemark=filemark)
 
     def _read_reactions(self):
         arrows = (
@@ -1331,8 +1417,10 @@ class ImportShewanellaOng(Importer):
             name = None if name.strip() == '' else name.strip()
             subsystem = None if subsystem.strip() == '' else subsystem
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, subsystem=subsystem)
+            filemark = FileMark(self._context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, subsystem=subsystem), filemark=filemark)
 
 
 class ImportiMR1_799(ImportShewanellaOng):  # noqa
@@ -1410,6 +1498,8 @@ class ImportModelSEED(Importer):
             raise ModelLoadError(
                 'More than one .xls file found in source directory')
 
+        self._excel_context = FilePathContext(excel_sources[0])
+
         ptt_sources = glob.glob(os.path.join(source, '*.ptt'))
         if len(ptt_sources) == 0:
             raise ModelLoadError('No .ptt file found in source directory')
@@ -1417,7 +1507,7 @@ class ImportModelSEED(Importer):
             raise ModelLoadError(
                 'More than one .ptt file found in source directory')
 
-        self._book = xlrd.open_workbook(excel_sources[0])
+        self._book = xlrd.open_workbook(self._excel_context.filepath)
 
         with open(ptt_sources[0], 'r') as ptt_file:
             # Read mapping from location to gene ID from PTT file
@@ -1471,8 +1561,10 @@ class ImportModelSEED(Importer):
             else:
                 formula = None
 
-            yield CompoundEntry(id=compound_id, name=name, formula=formula,
-                                charge=charge)
+            filemark = FileMark(self._excel_context, i, None)
+            yield CompoundEntry(dict(
+                id=compound_id, name=name, formula=formula,
+                charge=charge), filemark=filemark)
 
     def _read_reactions(self, peg_mapping):
         sheet = self._book.sheet_by_name('Reactions')
@@ -1513,5 +1605,7 @@ class ImportModelSEED(Importer):
                 ec_list = frozenset([ec_list])
                 ec = next(iter(ec_list))
 
-            yield ReactionEntry(id=reaction_id, name=name, genes=genes,
-                                equation=equation, ec=ec)
+            filemark = FileMark(self._excel_context, i, None)
+            yield ReactionEntry(dict(
+                id=reaction_id, name=name, genes=genes,
+                equation=equation, ec=ec), filemark=filemark)

--- a/psamm_import/importer.py
+++ b/psamm_import/importer.py
@@ -135,10 +135,10 @@ def get_default_compartment(model):
     default_compartment = 'c'
     default_key = set()
     for reaction_id, reaction in iteritems(model.reactions):
-        if 'equation' not in reaction.properties:
+        equation = reaction.equation
+        if equation is None:
             continue
 
-        equation = reaction.properties['equation']
         for compound, _ in equation.compounds:
             default_key.add(compound.compartment)
 

--- a/psamm_import/model.py
+++ b/psamm_import/model.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2015-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2015-2017  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Common metabolic model representations for imported models.
 
@@ -45,88 +45,6 @@ class ModelLoadError(ImportError):
 
 class ParseError(ImportError):
     """Exception used to signal an error parsing the model files."""
-
-
-class _BaseEntry(object):
-    """Base entry in loaded model."""
-
-    def __init__(self, **kwargs):
-        self._values = {key: value for key, value in iteritems(kwargs)
-                        if value is not None}
-        if 'id' not in self._values:
-            raise ValueError('No id was provided')
-        self._id = self._values['id']
-
-    @property
-    def id(self):
-        return self._id
-
-    @property
-    def properties(self):
-        return self._values
-
-
-class CompoundEntry(_BaseEntry):
-    """Compound entry in loaded model."""
-
-    @property
-    def name(self):
-        """Compound name."""
-        return self._values.get('name', None)
-
-    @property
-    def formula(self):
-        """Compound formula."""
-        return self._values.get('formula', None)
-
-    @property
-    def formula_neutral(self):
-        """Compound formula (neutral)."""
-        return self._values.get('formula_neutral', None)
-
-    @property
-    def charge(self):
-        """Compound charge."""
-        return self._values.get('charge', None)
-
-    @property
-    def kegg(self):
-        """KEGG identifier."""
-        return self._values.get('kegg', None)
-
-    @property
-    def cas(self):
-        """CAS identifier."""
-        return self._values.get('cas', None)
-
-
-class ReactionEntry(_BaseEntry):
-    """Reaction entry in loaded model."""
-
-    @property
-    def name(self):
-        """Reaction name."""
-        return self._values.get('name', None)
-
-    @property
-    def genes(self):
-        """Gene list or boolean expression."""
-        return self._values.get('genes', None)
-
-    @property
-    def equation(self):
-        """Reaction equation."""
-        return self._values.get('equation', None)
-
-    @property
-    def subsystem(self):
-        """Reaction subsystem classification."""
-        return self._values.get('subsystem', None)
-
-    @property
-    def ec(self):
-        """EC classifier."""
-        return self._values.get('ec', None)
 
 
 class MetabolicModel(object):
@@ -323,10 +241,10 @@ def detect_extracellular_compartment(model):
     extracellular_key = Counter()
 
     for reaction_id, reaction in iteritems(model.reactions):
-        if 'equation' not in reaction.properties:
+        equation = reaction.equation
+        if equation is None:
             continue
 
-        equation = reaction.properties['equation']
         if len(equation.compounds) == 1:
             compound, _ = equation.compounds[0]
             compartment = compound.compartment

--- a/psamm_import/model.py
+++ b/psamm_import/model.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PSAMM.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright 2015  Jon Lund Steffensen <jon_steffensen@uri.edu>
+# Copyright 2015-2016  Jon Lund Steffensen <jon_steffensen@uri.edu>
 
 """Common metabolic model representations for imported models.
 
@@ -22,6 +22,7 @@ result of parsing a model before it is converted to YAML format.
 """
 
 import logging
+from collections import Counter
 
 from six import iteritems, itervalues, text_type
 
@@ -29,6 +30,7 @@ from psamm.expression import boolean
 from psamm.datasource.reaction import (parse_reaction,
                                        ParseError as ReactionParseError)
 from psamm import formula
+from psamm.reaction import Direction
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ class _BaseEntry(object):
 
     @property
     def properties(self):
-        return dict(self._values)
+        return self._values
 
 
 class CompoundEntry(_BaseEntry):
@@ -130,12 +132,28 @@ class ReactionEntry(_BaseEntry):
 class MetabolicModel(object):
     """Intermediate model representation parsed from external source."""
 
-    def __init__(self, name, compounds, reactions):
+    def __init__(self, compounds, reactions):
         """Create model with name, compounds and reactions."""
-        self._name = name
         self._compounds = dict((c.id, c) for c in compounds)
-        self._reactions = dict((r.id, r) for r in reactions)
+
+        self._reactions = {}
+        self._limits = {}
+        for reaction in reactions:
+            # Extract flux limits embedded in reaction properties
+            lower_flux = reaction.properties.pop('lower_flux', None)
+            upper_flux = reaction.properties.pop('upper_flux', None)
+            if lower_flux is not None or upper_flux is not None:
+                self._limits[reaction.id] = lower_flux, upper_flux
+
+            self._reactions[reaction.id] = reaction
+
+        self._medium = {}
+
+        self._name = None
         self._biomass_reaction = None
+        self._extracellular_compartment = None
+        self._default_compartment = None
+        self._default_flux_limit = None
 
         self._genes = set()
         for r in itervalues(self._reactions):
@@ -151,6 +169,10 @@ class MetabolicModel(object):
     def name(self):
         """Model name."""
         return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
 
     @property
     def reactions(self):
@@ -168,6 +190,16 @@ class MetabolicModel(object):
         return self._genes
 
     @property
+    def limits(self):
+        """Return limits on reaction fluxes."""
+        return self._limits
+
+    @property
+    def medium(self):
+        """Medium definition."""
+        return self._medium
+
+    @property
     def biomass_reaction(self):
         """Main biomass reaction of model."""
         return self._biomass_reaction
@@ -177,6 +209,33 @@ class MetabolicModel(object):
         if value is not None and value not in self._reactions:
             raise ValueError('Invalid reaction')
         self._biomass_reaction = value
+
+    @property
+    def extracellular_compartment(self):
+        """Extracellular compartment specified by the model."""
+        return self._extracellular_compartment
+
+    @extracellular_compartment.setter
+    def extracellular_compartment(self, value):
+        self._extracellular_compartment = value
+
+    @property
+    def default_compartment(self):
+        """Default compartment specified by the model."""
+        return self._default_compartment
+
+    @default_compartment.setter
+    def default_compartment(self, value):
+        self._default_compartment = value
+
+    @property
+    def default_flux_limit(self):
+        """Default flux limit specified by the model."""
+        return self._default_flux_limit
+
+    @default_flux_limit.setter
+    def default_flux_limit(self, value):
+        self._default_flux_limit = value
 
     def print_summary(self):
         """Print model summary."""
@@ -257,3 +316,90 @@ class Importer(object):
             logger.warning(msg)
 
         return s
+
+
+def detect_extracellular_compartment(model):
+    """Detect the identifier for equations with extracellular compartments."""
+    extracellular_key = Counter()
+
+    for reaction_id, reaction in iteritems(model.reactions):
+        if 'equation' not in reaction.properties:
+            continue
+
+        equation = reaction.properties['equation']
+        if len(equation.compounds) == 1:
+            compound, _ = equation.compounds[0]
+            compartment = compound.compartment
+            extracellular_key[compartment] += 1
+    if len(extracellular_key) == 0:
+        return None
+    else:
+        best_key, _ = extracellular_key.most_common(1)[0]
+    logger.info('{} is extracellular compartment'.format(best_key))
+    return best_key
+
+
+def convert_exchange_to_medium(model):
+    """Convert exchange reactions in model to medium definition.
+
+    Only exchange reactions in the extracellular compartment are converted to
+    medium. The extracelluar compartment must be defined for the model.
+    """
+    # Build set of exchange reactions
+    exchanges = set()
+    for reaction_id, reaction in iteritems(model.reactions):
+        equation = reaction.properties.get('equation')
+        if equation is None:
+            continue
+
+        if len(equation.compounds) != 1:
+            # Provide warning for exchange reactions with more than
+            # one compound, they won't be put into the medium definition
+            if (len(equation.left) == 0) != (len(equation.right) == 0):
+                logger.warning('Exchange reaction {} has more than one'
+                               ' compound, it was not converted to'
+                               ' medium compounds'.format(reaction.id))
+            continue
+
+        exchanges.add(reaction_id)
+
+    # Convert exchange reactions into medium
+    for reaction_id in exchanges:
+        equation = model.reactions[reaction_id].properties['equation']
+        compound, value = equation.compounds[0]
+        if compound.compartment != model.extracellular_compartment:
+            continue
+
+        if compound in model.medium:
+            logger.warning(
+                'Compound {} is already defined in the medium'.format(
+                    compound))
+            continue
+
+        # We multiply the flux bounds by value in order to create equivalent
+        # exchange reactions with stoichiometric value of one. If the flux
+        # bounds are not set but the reaction is unidirectional, the implicit
+        # flux bounds must be used.
+        lower_flux, upper_flux = None, None
+        if reaction_id in model.limits:
+            lower, upper = model.limits[reaction_id]
+            if lower is not None:
+                lower_flux = lower * abs(value)
+            if upper is not None:
+                upper_flux = upper * abs(value)
+        elif equation.direction == Direction.Forward:
+            lower_flux = 0.0
+        elif equation.direction == Direction.Reverse:
+            upper_flux = 0.0
+
+        # If the stoichiometric value of the reaction is reversed, the flux
+        # limits must be flipped.
+        if value > 0:
+            lower_flux, upper_flux = (
+                -upper_flux if upper_flux is not None else None,
+                -lower_flux if lower_flux is not None else None)
+
+        model.medium[compound] = reaction_id, lower_flux, upper_flux
+
+        del model.reactions[reaction_id]
+        model.limits.pop(reaction_id, None)


### PR DESCRIPTION
Change MetabolicModel to make it easier to perform import in multiple passes, modifying the model during each pass. In addition, the model now uses the entries from the main PSAMM package as well as the ModelWriter for writing reactions and compounds.